### PR TITLE
Amendments to y2038

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+
+.DELETE_ON_ERROR:
+
 .PHONY : test bench clean tap_tests localtime_tests
 
 OPTIMIZE = -g

--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,11 @@ WARNINGS = -W -Wall -ansi -pedantic -Wno-long-long -Wextra -Wdeclaration-after-s
 INCLUDE  = -I.
 CFLAGS   = $(WARNINGS) $(OPTIMIZE) $(INCLUDE)
 TIME64_OBJECTS = time64.o
+CHECK_MAX_BIN=bin/check_max
 
-all : bin/check_max
+all : $(CHECK_MAX_BIN)
 
-bin/check_max : $(TIME64_OBJECTS)
+$(CHECK_MAX_BIN) : $(TIME64_OBJECTS)
 
 time64.o : time64_config.h time64_limits.h time64.h Makefile
 
@@ -60,6 +61,7 @@ clean:
 		t/*_test.out.bz2	\
 		t/bench			\
 		t/bench_system		\
+		$(CHECK_MAX_BIN)	\
 		*.o
 	-rm -rf	t/*.dSYM/		\
 		bin/*.dSYM/		\

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,9 @@
 OPTIMIZE = -g
 WARNINGS = -W -Wall -ansi -pedantic -Wno-long-long -Wextra -Wdeclaration-after-statement -Wendif-labels -Wconversion -Wcast-qual -Wwrite-strings
 INCLUDE  = -I.
+# Under Linux/glibc you will need flag _BSD_SOURCE for names tm_gmtoff and tm_zone (instead of __tm_gmtoff and __tm_zone) in struct tm,
+# and flag _POSIX_SOURCE (there are alternatives) for tzset().
+# CPPFLAGS = -D_BSD_SOURCE -D_POSIX_SOURCE
 CFLAGS   = $(WARNINGS) $(OPTIMIZE) $(INCLUDE)
 TIME64_OBJECTS = time64.o
 CHECK_MAX_BIN=bin/check_max

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 .PHONY : test bench clean tap_tests localtime_tests
 
 OPTIMIZE = -g
-WARNINGS = -W -Wall -ansi -pedantic -Wno-long-long -Wextra -Wdeclaration-after-statement -Wendif-labels -Wconversion -Wcast-qual -Wwrite-strings
+WARNINGS = -W -Wall -ansi -pedantic -Wno-long-long -Wextra -Wdeclaration-after-statement -Wendif-labels -Wconversion -Wcast-qual -Wwrite-strings -Wmissing-prototypes -Wc++-compat
 INCLUDE  = -I.
 # Under Linux/glibc you will need flag _BSD_SOURCE for names tm_gmtoff and tm_zone (instead of __tm_gmtoff and __tm_zone) in struct tm,
 # and flag _POSIX_SOURCE (there are alternatives) for tzset().

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ tap_tests: $(BLACKBOX_TESTS) $(GLASSBOX_TESTS)
 	@prove --exec '' t/*.t
 
 clean:
-	-rm 	t/*.t 			\
+	-rm -f 	t/*.t 			\
 	   	t/localtime_test	\
 		t/gmtime_test		\
 		t/*_test.out.bz2	\

--- a/README.txt
+++ b/README.txt
@@ -60,8 +60,4 @@ Portability
 I would like to add some configuration detection stuff in the future, but
 for now all I can do is document the assumptions...
 
-This code assumes that long longs are 64 bit integers which is technically
-in violation of the C standard.  This can be changed in time64.h by
-changing the Time64_T and Int64 typedefs.
-
 There are a number of configuration options in time64.h.

--- a/bin/check_max.c
+++ b/bin/check_max.c
@@ -15,8 +15,9 @@ time_t Time_Min;
 time_t Time_Zero = 0;
 
 
-char *dump_date(const struct tm *date) {
-    char *dump = malloc(80 * sizeof(char));
+/* Not really used anymore.
+static char *dump_date(const struct tm *date) {
+    char *dump = (char *) malloc(80 * sizeof(char));
     sprintf(
         dump,
         "{ %d, %d, %d, %d, %d, %d }",
@@ -25,15 +26,16 @@ char *dump_date(const struct tm *date) {
 
     return dump;
 }
+*/
 
 
 /* Visual C++ 2008's difftime() can't do negative times */
-double my_difftime(time_t left, time_t right) {
+static double my_difftime(time_t left, time_t right) {
     double diff = (double)left - (double)right;
     return diff;
 }
 
-time_t check_date_max( struct tm * (*date_func)(const time_t *), const char *func_name ) {
+static time_t check_date_max( struct tm * (*date_func)(const time_t *), const char *func_name ) {
     struct tm *date;
     time_t time        = Time_Max;
     time_t good_time   = 0;
@@ -62,7 +64,7 @@ time_t check_date_max( struct tm * (*date_func)(const time_t *), const char *fun
 }
 
 
-time_t check_date_min( struct tm * (*date_func)(const time_t *), const char *func_name ) {
+static time_t check_date_min( struct tm * (*date_func)(const time_t *), const char *func_name ) {
     struct tm *date;
     time_t time        = Time_Min;
     time_t good_time   = 0;
@@ -91,14 +93,14 @@ time_t check_date_min( struct tm * (*date_func)(const time_t *), const char *fun
 }
 
 
-struct tm * check_to_time_max( time_t (*to_time)(struct tm *), const char *func_name,
-                          struct tm * (*to_date)(const time_t *) )
+static struct tm * check_to_time_max( time_t (*to_time)(struct tm *), const char *func_name,
+                                      struct tm * (*to_date)(const time_t *) )
 {
     time_t round_trip;
     time_t time        = Time_Max;
     time_t good_time   = 0;
     struct tm *date;
-    struct tm *good_date = malloc(sizeof(struct tm));
+    struct tm *good_date = (struct tm *) malloc(sizeof(struct tm));
     time_t time_change = Time_Max;
 
     /* Binary search for the exact failure point */
@@ -126,14 +128,14 @@ struct tm * check_to_time_max( time_t (*to_time)(struct tm *), const char *func_
 }
 
 
-struct tm * check_to_time_min( time_t (*to_time)(struct tm *), const char *func_name,
-                          struct tm * (*to_date)(const time_t *) )
+static struct tm * check_to_time_min( time_t (*to_time)(struct tm *), const char *func_name,
+                                      struct tm * (*to_date)(const time_t *) )
 {
     time_t round_trip;
     time_t time        = Time_Min;
     time_t good_time   = 0;
     struct tm *date;
-    struct tm *good_date = malloc(sizeof(struct tm));
+    struct tm *good_date = (struct tm *) malloc(sizeof(struct tm));
     time_t time_change = Time_Min;
 
     /* Binary search for the exact failure point */
@@ -161,7 +163,7 @@ struct tm * check_to_time_min( time_t (*to_time)(struct tm *), const char *func_
 }
 
 
-void guess_time_limits_from_types(void) {
+static void guess_time_limits_from_types(void) {
     if( sizeof(time_t) == 4 ) {
         /* y2038 bug, out to 2**31-1 */
         Time_Max =  2147483647;
@@ -189,8 +191,8 @@ void guess_time_limits_from_types(void) {
 
 
 /* Dump a tm struct as a json fragment */
-char * tm_as_json(const struct tm* date) {
-    char *date_json = malloc(sizeof(char) * 512);
+static char * tm_as_json(const struct tm* date) {
+    char *date_json = (char *) malloc(sizeof(char) * 512);
 #ifdef HAS_TM_TM_ZONE
     char zone_json[32];
 #endif

--- a/time64.c
+++ b/time64.c
@@ -758,7 +758,7 @@ struct TM *localtime64_r (const Time64_T *time, struct TM *local_tm)
     /* GMT is Jan 1st, xx01 year, but localtime is still Dec 31st 
        in a non-leap xx00.  There is one point in the cycle
        we can't account for which the safe xx00 year is a leap
-       year.  So we need to correct for Dec 31st comming out as
+       year.  So we need to correct for Dec 31st coming out as
        the 366th day of the year.
     */
     if( !IS_LEAP(local_tm->tm_year) && local_tm->tm_yday == 365 )

--- a/time64.c
+++ b/time64.c
@@ -179,7 +179,7 @@ static int is_exception_century(Year year)
    The result is like cmp.
    Ignores things like gmtoffset and dst
 */
-int cmp_date( const struct TM* left, const struct tm* right ) {
+static int cmp_date( const struct TM* left, const struct tm* right ) {
     if( left->tm_year > right->tm_year )
         return 1;
     else if( left->tm_year < right->tm_year )
@@ -217,7 +217,7 @@ int cmp_date( const struct TM* left, const struct tm* right ) {
 /* Check if a date is safely inside a range.
    The intention is to check if its a few days inside.
 */
-int date_in_safe_range( const struct TM* date, const struct tm* min, const struct tm* max ) {
+static int date_in_safe_range( const struct TM* date, const struct tm* min, const struct tm* max ) {
     if( cmp_date(date, min) == -1 )
         return 0;
 
@@ -398,7 +398,7 @@ static int safe_year(const Year year)
 }
 
 
-void copy_tm_to_TM64(const struct tm *src, struct TM *dest) {
+static void copy_tm_to_TM64(const struct tm *src, struct TM *dest) {
     if( src == NULL ) {
         memset(dest, 0, sizeof(*dest));
     }
@@ -430,7 +430,7 @@ void copy_tm_to_TM64(const struct tm *src, struct TM *dest) {
 }
 
 
-void copy_TM64_to_tm(const struct TM *src, struct tm *dest) {
+static void copy_TM64_to_tm(const struct TM *src, struct tm *dest) {
     if( src == NULL ) {
         memset(dest, 0, sizeof(*dest));
     }
@@ -463,6 +463,8 @@ void copy_TM64_to_tm(const struct TM *src, struct tm *dest) {
 
 
 /* Simulate localtime_r() to the best of our ability */
+#ifndef HAS_LOCALTIME_R
+
 struct tm * fake_localtime_r(const time_t *time, struct tm *result) {
     const struct tm *static_result = localtime(time);
 
@@ -478,8 +480,12 @@ struct tm * fake_localtime_r(const time_t *time, struct tm *result) {
     }
 }
 
+#endif  /* #ifndef HAS_LOCALTIME_R */
+
 
 /* Simulate gmtime_r() to the best of our ability */
+#ifndef HAS_GMTIME_R
+
 struct tm * fake_gmtime_r(const time_t *time, struct tm *result) {
     const struct tm *static_result = gmtime(time);
 
@@ -494,6 +500,8 @@ struct tm * fake_gmtime_r(const time_t *time, struct tm *result) {
         return result;
     }
 }
+
+#endif  /* #ifndef HAS_GMTIME_R */
 
 
 static Time64_T seconds_between_years(Year left_year, Year right_year) {
@@ -786,14 +794,14 @@ struct TM *localtime64_r (const Time64_T *time, struct TM *local_tm)
 }
 
 
-int valid_tm_wday( const struct TM* date ) {
+static int valid_tm_wday( const struct TM* date ) {
     if( 0 <= date->tm_wday && date->tm_wday <= 6 )
         return 1;
     else
         return 0;
 }
 
-int valid_tm_mon( const struct TM* date ) {
+static int valid_tm_mon( const struct TM* date ) {
     if( 0 <= date->tm_mon && date->tm_mon <= 11 )
         return 1;
     else

--- a/time64.c
+++ b/time64.c
@@ -128,7 +128,8 @@ static const char dow_year_start[SOLAR_CYCLE_LENGTH] = {
 #define CHEAT_DAYS  (1199145600 / 24 / 60 / 60)
 #define CHEAT_YEARS 108
 
-#define IS_LEAP(n)      ((!(((n) + 1900) % 400) || (!(((n) + 1900) % 4) && (((n) + 1900) % 100))) != 0)
+/* IS_LEAP is used all over the place to index on arrays, so make sure it always returns 0 or 1. */
+#define IS_LEAP(n)      ( (!(((n) + 1900) % 400) || (!(((n) + 1900) % 4) && (((n) + 1900) % 100))) ? 1 : 0 )
 #define WRAP(a,b,m)     ((a) = ((a) <  0  ) ? ((b)--, (a) + (m)) : (a))
 
 #ifdef USE_SYSTEM_LOCALTIME

--- a/time64.c
+++ b/time64.c
@@ -234,19 +234,19 @@ Time64_T timegm64(const struct TM *date) {
     Time64_T seconds = 0;
     Year     year;
     Year     orig_year = (Year)date->tm_year;
-    int      cycles  = 0;
+    Year     cycles  = 0;
 
     if( orig_year > 100 ) {
         cycles = (orig_year - 100) / 400;
         orig_year -= cycles * 400;
-        days      += (Time64_T)cycles * days_in_gregorian_cycle;
+        days      += cycles * days_in_gregorian_cycle;
     }
     else if( orig_year < -300 ) {
         cycles = (orig_year - 100) / 400;
         orig_year -= cycles * 400;
-        days      += (Time64_T)cycles * days_in_gregorian_cycle;
+        days      += cycles * days_in_gregorian_cycle;
     }
-    TIME64_TRACE3("# timegm/ cycles: %d, days: %lld, orig_year: %lld\n", cycles, days, orig_year);
+    TIME64_TRACE3("# timegm/ cycles: %lld, days: %lld, orig_year: %lld\n", cycles, days, orig_year);
 
     if( orig_year > 70 ) {
         year = 70;
@@ -496,7 +496,7 @@ struct tm * fake_gmtime_r(const time_t *time, struct tm *result) {
 static Time64_T seconds_between_years(Year left_year, Year right_year) {
     int increment = (left_year > right_year) ? 1 : -1;
     Time64_T seconds = 0;
-    int cycles;
+    Year cycles;
 
     if( left_year > 2400 ) {
         cycles = (left_year - 2400) / 400;
@@ -564,7 +564,7 @@ struct TM *gmtime64_r (const Time64_T *in_time, struct TM *p)
     Time64_T m;
     Time64_T time = *in_time;
     Year year = 70;
-    int cycles = 0;
+    Year cycles = 0;
 
     assert(p != NULL);
 
@@ -613,10 +613,10 @@ struct TM *gmtime64_r (const Time64_T *in_time, struct TM *p)
 
     if (m >= 0) {
         /* Gregorian cycles, this is huge optimization for distant times */
-        cycles = (int)(m / (Time64_T) days_in_gregorian_cycle);
+        cycles = m / (Time64_T) days_in_gregorian_cycle;
         if( cycles ) {
-            m -= (cycles * (Time64_T) days_in_gregorian_cycle);
-            year += (cycles * years_in_gregorian_cycle);
+            m -= cycles * (Time64_T) days_in_gregorian_cycle;
+            year += cycles * years_in_gregorian_cycle;
         }
 
         /* Years */
@@ -637,10 +637,10 @@ struct TM *gmtime64_r (const Time64_T *in_time, struct TM *p)
         year--;
 
         /* Gregorian cycles */
-        cycles = (int)((m / (Time64_T) days_in_gregorian_cycle) + 1);
+        cycles = (m / (Time64_T) days_in_gregorian_cycle) + 1;
         if( cycles ) {
-            m -= (cycles * (Time64_T) days_in_gregorian_cycle);
-            year += (cycles * years_in_gregorian_cycle);
+            m -= cycles * (Time64_T) days_in_gregorian_cycle;
+            year += cycles * years_in_gregorian_cycle;
         }
 
         /* Years */

--- a/time64.c
+++ b/time64.c
@@ -660,7 +660,12 @@ struct TM *gmtime64_r (const Time64_T *in_time, struct TM *p)
         m += (Time64_T) days_in_month[leap][v_tm_mon];
     }
 
-    p->tm_year = year;
+#   ifdef USE_TM64
+      p->tm_year = year;
+#   else
+      p->tm_year = (int)year;
+#   endif
+
     if( p->tm_year != year ) {
 #ifdef EOVERFLOW
         errno = EOVERFLOW;
@@ -730,7 +735,12 @@ struct TM *localtime64_r (const Time64_T *time, struct TM *local_tm)
 
     copy_tm_to_TM64(&safe_date, local_tm);
 
-    local_tm->tm_year = orig_year;
+#   ifdef USE_TM64
+      local_tm->tm_year = orig_year;
+#   else
+      local_tm->tm_year = (int)orig_year;
+#   endif
+
     if( local_tm->tm_year != orig_year ) {
         TIME64_TRACE2("tm_year overflow: tm_year %lld, orig_year %lld\n",
               (Year)local_tm->tm_year, (Year)orig_year);

--- a/time64.c
+++ b/time64.c
@@ -280,7 +280,10 @@ static int check_tm(struct TM *tm)
 {
     /* Don't forget leap seconds */
     assert(tm->tm_sec >= 0);
-    assert(tm->tm_sec <= 61);
+
+    /* Allow for just one positive leap second, which is what the C99 standard says. */
+    /* Two leap seconds in the same minute are not allowed (the C90 range 0..61 was a defect). */
+    assert(tm->tm_sec <= 60);
 
     assert(tm->tm_min >= 0);
     assert(tm->tm_min <= 59);

--- a/time64.c
+++ b/time64.c
@@ -130,7 +130,9 @@ static const char dow_year_start[SOLAR_CYCLE_LENGTH] = {
 
 /* IS_LEAP is used all over the place to index on arrays, so make sure it always returns 0 or 1. */
 #define IS_LEAP(n)      ( (!(((n) + 1900) % 400) || (!(((n) + 1900) % 4) && (((n) + 1900) % 100))) ? 1 : 0 )
-#define WRAP(a,b,m)     ((a) = ((a) <  0  ) ? ((b)--, (a) + (m)) : (a))
+
+/* Allegedly, some <termios.h> define a macro called WRAP, so use a longer name like WRAP_TIME64. */
+#define WRAP_TIME64(a,b,m)     ((a) = ((a) <  0  ) ? ((b)--, (a) + (m)) : (a))
 
 #ifdef USE_SYSTEM_LOCALTIME
 #    define SHOULD_USE_SYSTEM_LOCALTIME(a)  (       \
@@ -598,9 +600,9 @@ struct TM *gmtime64_r (const Time64_T *in_time, struct TM *p)
     time /= 24;
     v_tm_tday = time;
 
-    WRAP (v_tm_sec, v_tm_min, 60);
-    WRAP (v_tm_min, v_tm_hour, 60);
-    WRAP (v_tm_hour, v_tm_tday, 24);
+    WRAP_TIME64 (v_tm_sec, v_tm_min, 60);
+    WRAP_TIME64 (v_tm_min, v_tm_hour, 60);
+    WRAP_TIME64 (v_tm_hour, v_tm_tday, 24);
 
     v_tm_wday = (int)((v_tm_tday + 4) % 7);
     if (v_tm_wday < 0)

--- a/time64.h
+++ b/time64.h
@@ -27,7 +27,7 @@ struct TM64 {
 #endif
 
 #ifdef HAS_TM_TM_ZONE
-        char    *tm_zone;
+        const char *tm_zone;
 #endif
 };
 

--- a/time64.h
+++ b/time64.h
@@ -4,6 +4,10 @@
 #include <time.h>
 #include "time64_config.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Set our custom types */
 typedef INT_64_T        Int64;
 typedef Int64           Time64_T;
@@ -77,5 +81,8 @@ Time64_T   timelocal64   (struct TM *);
     #define TM64_ASCTIME_FORMAT "%.3s %.3s%3d %.2d:%.2d:%.2d %d\n"
 #endif
 
+#ifdef __cplusplus
+  };
+#endif
 
 #endif

--- a/time64_config.h
+++ b/time64_config.h
@@ -49,12 +49,15 @@
 /* Details of non-standard tm struct elements.
 
    HAS_TM_TM_GMTOFF
-   True if your tm struct has a "tm_gmtoff" element.
+   Defined if your tm struct has a "tm_gmtoff" element.
    A BSD extension.
 
    HAS_TM_TM_ZONE
-   True if your tm struct has a "tm_zone" element.
+   Defined if your tm struct has a "tm_zone" element.
    A BSD extension.
+
+   If you define these symbols Under Linux/glibc, you either need to define _BSD_SOURCE before including time.h,
+   or change time64's source code to use names __tm_gmtoff and __tm_zone instead of tm_gmtoff and tm_zone.
 */
 /* #define HAS_TM_TM_GMTOFF */
 /* #define HAS_TM_TM_ZONE */

--- a/time64_config.h
+++ b/time64_config.h
@@ -4,6 +4,8 @@
    Sensible defaults provided.
 */
 
+#include <stdint.h>   /* If your system does not have stdint.h or does not define int64_t, you can use 'long long' instead, */
+                      /* but then make sure that 'long long' is indeed a 64-bit signed integer on your platform. */
 
 #ifndef TIME64_CONFIG_H
 #    define TIME64_CONFIG_H
@@ -19,7 +21,7 @@
    A 64 bit integer type to use to store time and others.
    Must be defined.
 */
-#define INT_64_T                long long
+#define INT_64_T                int64_t
 
 
 /* USE_TM64

--- a/time64_limits.h
+++ b/time64_limits.h
@@ -1,6 +1,7 @@
-/* 
+/* This header file is to be considered private to time64.c, so do not include it from your code.
+
    Maximum and minimum inputs your system's respective time functions
-   can correctly handle.  time64.h will use your system functions if
+   can correctly handle.  time64 will use your system functions if
    the input falls inside these ranges and corresponding USE_SYSTEM_*
    constant is defined.
 */


### PR DESCRIPTION
Hallo Schwern:

I have made all changes as discussed plus a few more. Points left are:

1) One of the tests was failing on my Linux system before I started making any changes to the project:

  # mktime64(140728004163928)
  # have: 12344592500
  # want: 12344678900
  t/mktime64.t ............... Failed 1/17 subtests

  Could you please take a look at it?

2) I am a bit worried that the code in timegm64() that calculates dates
   is not in sync with the code currently in Perl's source code.
   There are other places like safe_year() that have more validation in your version than in Perl.
   You are one of the Perl gurus, aren't you? Could you try to get those changes merged into Perl?

3) The Perl's source codes uses floating point, which seems a waste of time, search for Perl_fmod().

Thanks,
  rdiez
