### PR TITLE
mktime64 test fixes, and optimizations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ nytprof*
 .DS_Store
 MYMETA.yml
 *.o
+*.i
 t/bench
 t/bench_system
 t/*.out.bz2

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 .PHONY : test bench clean tap_tests localtime_tests
 
 OPTIMIZE = -g
-WARNINGS = -W -Wall -ansi -pedantic -Wno-long-long -Wextra -Wdeclaration-after-statement -Wendif-labels -Wconversion -Wcast-qual -Wwrite-strings
+WARNINGS = -W -Wall -ansi -pedantic -Wno-long-long -Wextra -Wdeclaration-after-statement -Wendif-labels -Wconversion -Wcast-qual -Wwrite-strings -Wmissing-prototypes -Wc++-compat
 INCLUDE  = -I.
 DEBUG    = -DTIME_64_DEBUG
 # Under Linux/glibc you will need flag _BSD_SOURCE for names tm_gmtoff and tm_zone (instead of __tm_gmtoff and __tm_zone) in struct tm,

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+
+.DELETE_ON_ERROR:
+
 .PHONY : test bench clean tap_tests localtime_tests
 
 OPTIMIZE = -g

--- a/Makefile
+++ b/Makefile
@@ -7,13 +7,15 @@ OPTIMIZE = -g
 WARNINGS = -W -Wall -ansi -pedantic -Wno-long-long -Wextra -Wdeclaration-after-statement -Wendif-labels -Wconversion -Wcast-qual -Wwrite-strings -Wmissing-prototypes -Wc++-compat
 INCLUDE  = -I.
 DEBUG    = -DTIME_64_DEBUG
-# Under Linux/glibc you will need flag _BSD_SOURCE for names tm_gmtoff and tm_zone (instead of __tm_gmtoff and __tm_zone) in struct tm,
-# and flag _POSIX_SOURCE (there are alternatives) for tzset().
-# CPPFLAGS = -D_BSD_SOURCE -D_POSIX_SOURCE
 CFLAGS   = $(WARNINGS) $(OPTIMIZE) $(INCLUDE)
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Darwin)
   CFLAGS += -DHAS_TM_TM_GMTOFF -DHAS_TM_TM_ZONE
+endif
+ifeq ($(UNAME_S),Linux)
+  # Under Linux/glibc you will need flag _BSD_SOURCE for names tm_gmtoff and tm_zone (instead of __tm_gmtoff and __tm_zone) in struct tm,
+  # and flag _POSIX_SOURCE (there are alternatives) for tzset().
+  CFLAGS += -D_BSD_SOURCE -D_POSIX_SOURCE
 endif
 TIME64_OBJECTS = time64.o
 CHECK_MAX_BIN=bin/check_max

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,10 @@ ifneq ($(DEBUG),)
   CFLAGS  += -DTIME_64_DEBUG
   OPTIMIZE = -g
 endif
+# use 64bit but incompatible struct tm
+ifeq ($(USE_TM64),1)
+  CFLAGS  += -DUSE_TM64
+endif
 
 TIME64_OBJECTS = time64.o
 CHECK_MAX_BIN  = bin/check_max

--- a/Makefile
+++ b/Makefile
@@ -3,22 +3,31 @@
 
 .PHONY : test bench clean tap_tests localtime_tests
 
-OPTIMIZE = -g
-WARNINGS = -W -Wall -ansi -pedantic -Wno-long-long -Wextra -Wdeclaration-after-statement -Wendif-labels -Wconversion -Wcast-qual -Wwrite-strings -Wmissing-prototypes -Wc++-compat
+OPTIMIZE = -O3 -g
+WARNINGS = -W -Wall -Wextra -ansi -pedantic -Wno-long-long -Wdeclaration-after-statement \
+  -Wendif-labels -Wconversion -Wcast-qual -Wwrite-strings -Wmissing-prototypes \
+  -Wc++-compat
+#clang: -Wno-incompatible-pointer-types-discards-qualifiers
+#gcc:   -Wno-discarded-qualifiers
 INCLUDE  = -I.
-DEBUG    = -DTIME_64_DEBUG
 CFLAGS   = $(WARNINGS) $(OPTIMIZE) $(INCLUDE)
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Darwin)
   CFLAGS += -DHAS_TM_TM_GMTOFF -DHAS_TM_TM_ZONE
 endif
 ifeq ($(UNAME_S),Linux)
-  # Under Linux/glibc you will need flag _BSD_SOURCE for names tm_gmtoff and tm_zone (instead of __tm_gmtoff and __tm_zone) in struct tm,
-  # and flag _POSIX_SOURCE (there are alternatives) for tzset().
+  # Under Linux/glibc you will need flag _BSD_SOURCE for names tm_gmtoff and tm_zone
+  # (instead of __tm_gmtoff and __tm_zone) in struct tm,
+  # and _POSIX_SOURCE (there are alternatives) for tzset().
   CFLAGS += -D_BSD_SOURCE -D_POSIX_SOURCE
 endif
+ifneq ($(DEBUG),)
+  CFLAGS  += -DTIME_64_DEBUG
+  OPTIMIZE = -g
+endif
+
 TIME64_OBJECTS = time64.o
-CHECK_MAX_BIN=bin/check_max
+CHECK_MAX_BIN  = bin/check_max
 
 all : $(CHECK_MAX_BIN)
 
@@ -34,7 +43,6 @@ bench : t/bench t/bench_system
 	time t/bench
 
 t/bench t/bench_system : $(TIME64_OBJECTS)
-
 t/localtime_test : $(TIME64_OBJECTS)
 t/gmtime_test : $(TIME64_OBJECTS)
 

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,8 @@ ifeq ($(UNAME_S),Linux)
   # (instead of __tm_gmtoff and __tm_zone) in struct tm,
   # and _POSIX_SOURCE (there are alternatives) for tzset().
   # _BSD_SOURCE is deprecated, use _DEFAULT_SOURCE instead
-  CFLAGS += -D_DEFAULT_SOURCE -D_POSIX_SOURCE -DHAS_TM_TM_GMTOFF -DHAS_TM_TM_ZONE
+  CFLAGS += -D_BSD_SOURCE -D_DEFAULT_SOURCE -D_POSIX_SOURCE
+  #CFLAGS += -D_DEFAULT_SOURCE -D_POSIX_SOURCE -DHAS_TM_TM_GMTOFF -DHAS_TM_TM_ZONE
 endif
 ifneq ($(DEBUG),)
   CFLAGS  += -DTIME_64_DEBUG

--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,11 @@ INCLUDE  = -I.
 DEBUG    = -DTIME_64_DEBUG
 CFLAGS   = $(WARNINGS) $(OPTIMIZE) $(INCLUDE)
 TIME64_OBJECTS = time64.o
+CHECK_MAX_BIN=bin/check_max
 
-all : bin/check_max
+all : $(CHECK_MAX_BIN)
 
-bin/check_max : $(TIME64_OBJECTS)
+$(CHECK_MAX_BIN) : $(TIME64_OBJECTS)
 
 time64.o : time64_config.h time64_limits.h time64.h Makefile
 
@@ -63,6 +64,7 @@ clean:
 		t/*_test.out.bz2	\
 		t/bench			\
 		t/bench_system		\
+		$(CHECK_MAX_BIN)	\
 		*.o
 	-rm -rf	t/*.dSYM/		\
 		bin/*.dSYM/		\

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ OPTIMIZE = -g
 WARNINGS = -W -Wall -ansi -pedantic -Wno-long-long -Wextra -Wdeclaration-after-statement -Wendif-labels -Wconversion -Wcast-qual -Wwrite-strings
 INCLUDE  = -I.
 DEBUG    = -DTIME_64_DEBUG
+# Under Linux/glibc you will need flag _BSD_SOURCE for names tm_gmtoff and tm_zone (instead of __tm_gmtoff and __tm_zone) in struct tm,
+# and flag _POSIX_SOURCE (there are alternatives) for tzset().
+# CPPFLAGS = -D_BSD_SOURCE -D_POSIX_SOURCE
 CFLAGS   = $(WARNINGS) $(OPTIMIZE) $(INCLUDE)
 TIME64_OBJECTS = time64.o
 CHECK_MAX_BIN=bin/check_max

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,8 @@ ifeq ($(UNAME_S),Linux)
   # Under Linux/glibc you will need flag _BSD_SOURCE for names tm_gmtoff and tm_zone
   # (instead of __tm_gmtoff and __tm_zone) in struct tm,
   # and _POSIX_SOURCE (there are alternatives) for tzset().
-  CFLAGS += -D_BSD_SOURCE -D_POSIX_SOURCE
+  # _BSD_SOURCE is deprecated, use _DEFAULT_SOURCE instead
+  CFLAGS += -D_DEFAULT_SOURCE -D_POSIX_SOURCE -DHAS_TM_TM_GMTOFF -DHAS_TM_TM_ZONE
 endif
 ifneq ($(DEBUG),)
   CFLAGS  += -DTIME_64_DEBUG

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,10 @@ all : $(CHECK_MAX_BIN)
 
 $(CHECK_MAX_BIN) : $(TIME64_OBJECTS)
 
-time64.o : time64_config.h time64_limits.h time64.h Makefile
+time64.o time64.i: time64_config.h time64_limits.h time64.h Makefile
+
+%.i: %.c
+	$(CC) -c $(CFLAGS) -o $@ -E -c $<
 
 bench : t/bench t/bench_system
 	time t/bench_system

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ tap_tests: $(BLACKBOX_TESTS) $(GLASSBOX_TESTS)
 	@prove --exec '' t/*.t
 
 clean:
-	-rm 	t/*.t 			\
+	-rm -f 	t/*.t 			\
 	   	t/localtime_test	\
 		t/gmtime_test		\
 		t/*_test.out.bz2	\

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,10 @@ DEBUG    = -DTIME_64_DEBUG
 # and flag _POSIX_SOURCE (there are alternatives) for tzset().
 # CPPFLAGS = -D_BSD_SOURCE -D_POSIX_SOURCE
 CFLAGS   = $(WARNINGS) $(OPTIMIZE) $(INCLUDE)
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+  CFLAGS += -DHAS_TM_TM_GMTOFF -DHAS_TM_TM_ZONE
+endif
 TIME64_OBJECTS = time64.o
 CHECK_MAX_BIN=bin/check_max
 

--- a/README.txt
+++ b/README.txt
@@ -60,8 +60,4 @@ Portability
 I would like to add some configuration detection stuff in the future, but
 for now all I can do is document the assumptions...
 
-This code assumes that long longs are 64 bit integers which is technically
-in violation of the C standard.  This can be changed in time64.h by
-changing the Time64_T and Int64 typedefs.
-
 There are a number of configuration options in time64.h.

--- a/bin/check_max.c
+++ b/bin/check_max.c
@@ -15,8 +15,9 @@ time_t Time_Min;
 time_t Time_Zero = 0;
 
 
-char *dump_date(const struct tm *date) {
-    char *dump = malloc(80 * sizeof(char));
+/* Not really used anymore.
+static char *dump_date(const struct tm *date) {
+    char *dump = (char *) malloc(80 * sizeof(char));
     sprintf(
         dump,
         "{ %d, %d, %d, %d, %d, %d }",
@@ -25,15 +26,16 @@ char *dump_date(const struct tm *date) {
 
     return dump;
 }
+*/
 
 
 /* Visual C++ 2008's difftime() can't do negative times */
-double my_difftime(time_t left, time_t right) {
+static double my_difftime(time_t left, time_t right) {
     double diff = (double)left - (double)right;
     return diff;
 }
 
-time_t check_date_max( struct tm * (*date_func)(const time_t *), const char *func_name ) {
+static time_t check_date_max( struct tm * (*date_func)(const time_t *), const char *func_name ) {
     struct tm *date;
     time_t time        = Time_Max;
     time_t good_time   = 0;
@@ -62,7 +64,7 @@ time_t check_date_max( struct tm * (*date_func)(const time_t *), const char *fun
 }
 
 
-time_t check_date_min( struct tm * (*date_func)(const time_t *), const char *func_name ) {
+static time_t check_date_min( struct tm * (*date_func)(const time_t *), const char *func_name ) {
     struct tm *date;
     time_t time        = Time_Min;
     time_t good_time   = 0;
@@ -91,14 +93,14 @@ time_t check_date_min( struct tm * (*date_func)(const time_t *), const char *fun
 }
 
 
-struct tm * check_to_time_max( time_t (*to_time)(struct tm *), const char *func_name,
-                          struct tm * (*to_date)(const time_t *) )
+static struct tm * check_to_time_max( time_t (*to_time)(struct tm *), const char *func_name,
+                                      struct tm * (*to_date)(const time_t *) )
 {
     time_t round_trip;
     time_t time        = Time_Max;
     time_t good_time   = 0;
     struct tm *date;
-    struct tm *good_date = malloc(sizeof(struct tm));
+    struct tm *good_date = (struct tm *) malloc(sizeof(struct tm));
     time_t time_change = Time_Max;
 
     /* Binary search for the exact failure point */
@@ -126,14 +128,14 @@ struct tm * check_to_time_max( time_t (*to_time)(struct tm *), const char *func_
 }
 
 
-struct tm * check_to_time_min( time_t (*to_time)(struct tm *), const char *func_name,
-                          struct tm * (*to_date)(const time_t *) )
+static struct tm * check_to_time_min( time_t (*to_time)(struct tm *), const char *func_name,
+                                      struct tm * (*to_date)(const time_t *) )
 {
     time_t round_trip;
     time_t time        = Time_Min;
     time_t good_time   = 0;
     struct tm *date;
-    struct tm *good_date = malloc(sizeof(struct tm));
+    struct tm *good_date = (struct tm *) malloc(sizeof(struct tm));
     time_t time_change = Time_Min;
 
     /* Binary search for the exact failure point */
@@ -161,7 +163,7 @@ struct tm * check_to_time_min( time_t (*to_time)(struct tm *), const char *func_
 }
 
 
-void guess_time_limits_from_types(void) {
+static void guess_time_limits_from_types(void) {
     if( sizeof(time_t) == 4 ) {
         /* y2038 bug, out to 2**31-1 */
         Time_Max =  2147483647;
@@ -189,8 +191,8 @@ void guess_time_limits_from_types(void) {
 
 
 /* Dump a tm struct as a json fragment */
-char * tm_as_json(const struct tm* date) {
-    char *date_json = malloc(sizeof(char) * 512);
+static char * tm_as_json(const struct tm* date) {
+    char *date_json = (char *) malloc(sizeof(char) * 512);
 #ifdef HAS_TM_TM_ZONE
     char zone_json[32];
 #endif

--- a/t/asctime64.t.c
+++ b/t/asctime64.t.c
@@ -43,7 +43,7 @@ int main(void) {
     date.tm_hour = 5;
     asctime_r_ret2 = asctime64_r( &date, asctime_r_buf2 );
     is_str( asctime_r_buf2,  "Mon May  4 05:02:42 234567\n", "asctime64_r() again" );
-    is_str( asctime_r_ret1,  "Mon May  4 03:02:42 234567\n", "  return not static" );
+    is_str( asctime_r_ret2,  "Mon May  4 05:02:42 234567\n", "  return not static" );
 
     /* Upon successful completion, asctime() shall return a pointer to the string.
        If the function is unsuccessful, it shall return NULL. (ISO)

--- a/t/gmtime64.t.c
+++ b/t/gmtime64.t.c
@@ -1,6 +1,8 @@
+#include <stdio.h>
 #include "time64.h"
 #include "t/tap.h"
-#include <stdio.h>
+
+void test_non_reentrant(void);
 
 /* Test that the non-reentrant functions share the same memory */
 void test_non_reentrant(void) {

--- a/t/gmtime64.t.c
+++ b/t/gmtime64.t.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <inttypes.h>
 #include "time64.h"
 #include "t/tap.h"
 
@@ -29,12 +30,12 @@ int main(void) {
     for( time = -6000000000LL;  time < 6000000000LL; time += 712359 ) {
         localtime64_r(&time, &want_date);
         have_date = localtime64(&time);
-        sprintf(name, "localtime64(%lld)", time);
+        sprintf(name, "localtime64(%"PRId64")", time);
         tm_is( have_date, &want_date, name );
 
         gmtime64_r(&time, &want_date);
         have_date = gmtime64(&time);
-        sprintf(name, "gmtime64(%lld)", time);
+        sprintf(name, "gmtime64(%"PRId64")", time);
         tm_is( have_date, &want_date, name );
     }
 

--- a/t/gmtime_test.c
+++ b/t/gmtime_test.c
@@ -11,7 +11,7 @@ int main(void)
 
     while(d.tm_year < 800) {
         gmtime64_r(&time, &d);
-        printf("%lld %d %d %d %d %d %lld %d %d %d\n",
+        printf("%"PRId64" %d %d %d %d %d %"PRId64" %d %d %d\n",
                 time,
                 d.tm_sec,
                 d.tm_min,

--- a/t/localtime_test.c
+++ b/t/localtime_test.c
@@ -11,7 +11,7 @@ int main(void)
 
     while(d.tm_year < 800) {
         localtime64_r(&time, &d);
-        printf("%lld %d %d %d %d %d %lld %d %d %d\n",
+        printf("%"PRId64" %d %d %d %d %d %"PRId64" %d %d %d\n",
                 time,
                 d.tm_sec,
                 d.tm_min,

--- a/t/mktime64.t.c
+++ b/t/mktime64.t.c
@@ -1,5 +1,6 @@
 #include "time64.h"
 #include "t/tap.h"
+#define IS_LEAP_ABS(n)  (!((n) % 400) || (!((n) % 4) && ((n) % 100) && ((n) > 0)))
 
 int mktime64_ok(Time64_T time);
 
@@ -13,17 +14,23 @@ int mktime64_ok(Time64_T time) {
 int main(void) {
     struct TM date;
     Time64_T time;
+    Year year;
+    const short length_of_year[2] = { 365, 366 };
+#ifdef TIME_64_DEBUG
+    char result[60];
+#endif
 
     /* Some basic round trip mktime64 tests */
     mktime64_ok((Time64_T)0);
     mktime64_ok((Time64_T)1);
     mktime64_ok((Time64_T)-1);
     mktime64_ok((Time64_T)60*60*24*15);
-    mktime64_ok((Time64_T)60*60*24*15);
+    mktime64_ok((Time64_T)-60*60*24*15);
     mktime64_ok((Time64_T)60*60*24*365*143);
     mktime64_ok((Time64_T)-60*60*24*365*143);
     mktime64_ok((Time64_T)60*60*24*365*433);
     mktime64_ok((Time64_T)-60*60*24*365*433);
+    mktime64_ok((Time64_T)573942500); /* a leap year */
     mktime64_ok((Time64_T)-2147483647);
     mktime64_ok((Time64_T)2147483647);
 
@@ -39,36 +46,64 @@ int main(void) {
      * are not restricted to the ranges described in <time.h>.
      * http://www.opengroup.org/onlinepubs/009695399/functions/mktime.html
      */
-    date.tm_mday = 35;
+    year = 1981;
+    /* Thu Apr  9 12:28:20 1981 */
+    date.tm_sec  = 20;
+    date.tm_min  = 28;
+    date.tm_hour = 11;  /* avoid overflow to prev or next day on other timezones */
+    date.tm_mon  = 3;
+    date.tm_mday = 9;
+    date.tm_year = (year_t)(year - 1900);
+    time = mktime64(&date);
+#ifdef TIME_64_DEBUG
+    diag ("time = %lld", time); /* 355660100LL */
+    diag ("time = %s", asctime64_r(&date, result));
+#endif 
+    for (; year < 2400;
+           year++, time += length_of_year[IS_LEAP_ABS(year)] * 60 * 60 * 24)
+    {
+      date.tm_sec  = 20;
+      date.tm_min  = 28;
+      date.tm_year = (year_t)(year - 1900);
+      date.tm_mon  = 2;   /* Mar 40 == Apr 9, avoid Feb leap day */
+      date.tm_mday = 40;
+      date.tm_wday = 9;   /* deliberately wrong week day */
+      date.tm_yday = 487; /* and wrong year day */
 
-    time = 12344678900LL;     /* Thu Mar  9 21:28:20 2361 */
+      /* Upon successful completion, the values of the tm_wday and tm_yday
+       * components of the structure shall be set appropriately, and the other
+       * components are set to represent the specified time since the Epoch,
+       * but with their values forced to the ranges indicated in the <time.h>
+       * entry; the final value of tm_mday shall not be set until tm_mon and
+       * tm_year are determined.
+       * http://www.opengroup.org/onlinepubs/009695399/functions/mktime.html
+       */
+      is_Int64( mktime64(&date), time, "mktime64(%"PRId64") oob, year:%ld",
+                time, (long)year );
+      /*diag ("time = %s", asctime64_r(&date, result));*/
+    }
+    
+    time = 12347288900LL;     /* Sun Apr  9 12:28:20 2361 PST */
     localtime64_r(&time, &date);
-
-    /* Feb 37 == Mar 9 */
-    date.tm_mon  = 1;
-    date.tm_mday = 37;
-    date.tm_wday = 9;           /* deliberately wrong week day */
-    date.tm_yday = 487;         /* and wrong year day */
-#ifdef HAS_TM_TM_GMTOFF
-    /*date.tm_gmtoff = 0;*/
+#ifdef TIME_64_DEBUG
+    diag ("time = %s", asctime64_r(&date, result));
 #endif
-#ifdef HAS_TM_TM_ZONE
-    /*date.tm_zone = "UTC";*/
-#endif
+    /*date.tm_hour = 12;*/
+    date.tm_year = (year_t)(2361-1900);
+    date.tm_mon  = 2;         /* Mar 37 == Apr 9 */
+    date.tm_mday = 40;
+    date.tm_wday = 9;         /* deliberately wrong week day */
+    date.tm_yday = 487;       /* and wrong year day */
 
-    /* Upon successful completion, the values of the tm_wday and tm_yday
-     * components of the structure shall be set appropriately, and the other
-     * components are set to represent the specified time since the Epoch,
-     * but with their values forced to the ranges indicated in the <time.h>
-     * entry; the final value of tm_mday shall not be set until tm_mon and
-     * tm_year are determined.
-     * http://www.opengroup.org/onlinepubs/009695399/functions/mktime.html
-     */
-    is_Int64( mktime64(&date), time, "mktime64(%"PRId64")", time );
-    is_int( date.tm_mon,  2, "tm_mon corrected" );
+    is_Int64( mktime64(&date), time, "mktime64(%"PRId64") oob, year:2361",
+              time);
+#ifdef TIME_64_DEBUG
+    diag ("time = %s", asctime64_r(&date, result));
+#endif
+    is_int( date.tm_mon,  3, "tm_mon corrected" );
     is_int( date.tm_mday, 9, "tm_mday corrected" );
-    is_int( date.tm_yday, 67,"tm_yday corrected" );
-    is_int( date.tm_wday, 4, "tm_wday corrected" );
+    is_int( date.tm_yday, 98,"tm_yday corrected" );
+    is_int( date.tm_wday, 0, "tm_wday corrected" );
 
     done_testing();
     return 0;

--- a/t/mktime64.t.c
+++ b/t/mktime64.t.c
@@ -1,6 +1,8 @@
 #include "time64.h"
 #include "t/tap.h"
 
+int mktime64_ok(Time64_T time);
+
 int mktime64_ok(Time64_T time) {
     struct TM date;
 

--- a/t/mktime64.t.c
+++ b/t/mktime64.t.c
@@ -7,7 +7,7 @@ int mktime64_ok(Time64_T time) {
     struct TM date;
 
     localtime64_r(&time, &date);
-    return is_Int64( mktime64(&date), time, "mktime64(%lld)", time );
+    return is_Int64( mktime64(&date), time, "mktime64(%"PRId64")", time );
 }
 
 int main(void) {
@@ -33,7 +33,6 @@ int main(void) {
     localtime64_r(&time, &date);
     is_Int64( mktime64(&date), timelocal64(&date), "timelocal64 alias" );
 
-
     /* Test that mktime64 accepts and corrects out of bound dates */
     /* The original values of the tm_wday and tm_yday components of the
      * structure are ignored, and the original values of the other components
@@ -50,6 +49,12 @@ int main(void) {
     date.tm_mday = 37;
     date.tm_wday = 9;           /* deliberately wrong week day */
     date.tm_yday = 487;         /* and wrong year day */
+#ifdef HAS_TM_TM_GMTOFF
+    /*date.tm_gmtoff = 0;*/
+#endif
+#ifdef HAS_TM_TM_ZONE
+    /*date.tm_zone = "UTC";*/
+#endif
 
     /* Upon successful completion, the values of the tm_wday and tm_yday
      * components of the structure shall be set appropriately, and the other
@@ -59,7 +64,7 @@ int main(void) {
      * tm_year are determined.
      * http://www.opengroup.org/onlinepubs/009695399/functions/mktime.html
      */
-    is_Int64( mktime64(&date), time, "mktime64(%lld)", time );
+    is_Int64( mktime64(&date), time, "mktime64(%"PRId64")", time );
     is_int( date.tm_mon,  2, "tm_mon corrected" );
     is_int( date.tm_mday, 9, "tm_mday corrected" );
     is_int( date.tm_yday, 67,"tm_yday corrected" );

--- a/t/safe_year.t.c
+++ b/t/safe_year.t.c
@@ -8,7 +8,7 @@
 static void year_to_TM(const Year year, struct TM *date) {
     Time64_T time;
 
-    date->tm_year = year - 1900;
+    date->tm_year = (year_t)(year - 1900);
     date->tm_mon  = 0;
     date->tm_mday = 1;
     date->tm_hour = 0;
@@ -24,7 +24,7 @@ static void year_to_tm(const Year year, struct tm *ret) {
     Time64_T time;
     struct TM date;
 
-    date.tm_year = year - 1900;
+    date.tm_year = (year_t)(year - 1900);
     date.tm_mon  = 0;
     date.tm_mday = 1;
     date.tm_hour = 0;
@@ -60,7 +60,7 @@ static void test_safe_year(Year orig_year) {
     is_Int64( (Year)orig_tm.tm_year, (Year)(orig_year - 1900), "year_to_tm(orig)" );
     is_int( safe_tm.tm_year, year - 1900, "year_to_TM(safe)" );
 
-    ok(1, "orig_year: %lld, safe_year: %d", orig_year, year);
+    ok(1, "orig_year: %"PRId64", safe_year: %d", orig_year, year);
     is_int( safe_tm.tm_wday, orig_tm.tm_wday,                      "  tm_wday" );
     is_int( IS_LEAP( year - 1900 ), IS_LEAP( orig_year - 1900 ),   "  ISLEAP()" );
 

--- a/t/safe_year.t.c
+++ b/t/safe_year.t.c
@@ -43,13 +43,14 @@ static void test_safe_year(Year orig_year) {
     struct TM orig_tm;
 
     if( orig_year > 1970 && orig_year < 2038 ) {
-        is_Int64( orig_year, (Year)year, "safe_year() returns same year if already safe" );
+        is_Int64( orig_year, (Year)year, "safe_year(%d) returns same year if already safe",
+                  orig_year);
     }
     else if( orig_year <= 1970 ) {
-        ok( year < 2000, "safe_year() < 2000 for year <= 1970" );
+        ok( year < 2000, "safe_year(%d) < 2000 for year <= 1970", year );
     }
     else if( orig_year >= 2038 ) {
-        ok( year > 2000, "safe_year() > 2000 for year >= 2038" );
+        ok( year > 2000, "safe_year(%d) > 2000 for year >= 2038", year );
     }
     else {
         assert(0);
@@ -57,25 +58,29 @@ static void test_safe_year(Year orig_year) {
 
     year_to_tm((Year)year, &safe_tm);
     year_to_TM(orig_year, &orig_tm);
-    is_Int64( (Year)orig_tm.tm_year, (Year)(orig_year - 1900), "year_to_tm(orig)" );
-    is_int( safe_tm.tm_year, year - 1900, "year_to_TM(safe)" );
+    is_Int64( (Year)orig_tm.tm_year, (Year)(orig_year - 1900), "year_to_tm(orig %d)",
+              (int)orig_year );
+    is_int( safe_tm.tm_year, year - 1900, "year_to_TM(safe %d)", year );
 
     ok(1, "orig_year: %"PRId64", safe_year: %d", orig_year, year);
     is_int( safe_tm.tm_wday, orig_tm.tm_wday,                      "  tm_wday" );
-    is_int( IS_LEAP( year - 1900 ), IS_LEAP( orig_year - 1900 ),   "  ISLEAP()" );
+    is_int( IS_LEAP( year - 1900), IS_LEAP( orig_year - 1900),   "  ISLEAP(%d)", year );
+    if (orig_year > 0)
+        is_int( IS_LEAP_ABS(year), IS_LEAP_ABS(orig_year),   "  ISLEAP_ABS(%d)", year );
 
     year--;
     orig_year--;
     year_to_tm((Year)year, &safe_tm);
     year_to_TM(orig_year, &orig_tm);
-    is_int( safe_tm.tm_wday, orig_tm.tm_wday,                      "  previous tm_wday" );
-    is_int( IS_LEAP( year - 1900 ), IS_LEAP( orig_year - 1900 ),   "  previous ISLEAP()" );
+    is_int( safe_tm.tm_wday, orig_tm.tm_wday,            "  previous tm_wday" );
+    if (orig_year > 0)
+        is_int( IS_LEAP_ABS(year), IS_LEAP_ABS(orig_year),"  previous ISLEAP(%d)", orig_year );
 
     year += 2;
     orig_year += 2;
     year_to_tm((Year)year, &safe_tm);
     year_to_TM(orig_year, &orig_tm);
-    is_int( safe_tm.tm_wday, orig_tm.tm_wday,                           "  next tm_wday" );
+    is_int( safe_tm.tm_wday, orig_tm.tm_wday,            "  next tm_wday" );
     /* Don't care about the next leap status */
 }
 

--- a/t/tap.c
+++ b/t/tap.c
@@ -5,8 +5,9 @@
 #include <time.h>
 #include "time64.h"
 
-int Test_Count = 0;
+#include "tap.h"
 
+int Test_Count = 0;
 
 int diag(const char *message, ...) {
     va_list args;
@@ -29,6 +30,7 @@ void skip_all(const char *reason) {
 
 
 int do_test(const int test, const char *message, va_list args) {
+
     Test_Count++;
 
     printf("%s %d ", (test ? "ok" : "not ok"), Test_Count);

--- a/t/tap.c
+++ b/t/tap.c
@@ -40,7 +40,6 @@ int do_test(const int test, const char *message, va_list args) {
 
     if( !test ) {
         diag("Failed test");
-        diag(message, args);
     }
 
     return test;
@@ -87,8 +86,7 @@ int is_str(const char* have, const char* want, const char *message, ...) {
     do_test( test, message, args );
 
     if( !test ) {
-        diag("have: %s", have);
-        diag("want: %s", want);
+      diag("have: %s, want: %s", have, want);
     }
 
     va_end(args);
@@ -106,8 +104,7 @@ int is_Int64(const Int64 have, const Int64 want, const char *name, ...) {
     do_test( test, name, args );
 
     if( !test ) {
-        diag("have: %"PRId64, have);
-        diag("want: %"PRId64, want);
+        diag("have: %"PRId64" want: %"PRId64" diff: %"PRId64, have, want, have-want);
     }
 
     va_end(args);

--- a/t/tap.c
+++ b/t/tap.c
@@ -3,6 +3,7 @@
 #include <stdarg.h>
 #include <string.h>
 #include <time.h>
+#include <inttypes.h>
 #include "time64.h"
 
 #include "tap.h"
@@ -105,8 +106,8 @@ int is_Int64(const Int64 have, const Int64 want, const char *name, ...) {
     do_test( test, name, args );
 
     if( !test ) {
-        diag("have: %lld", have);
-        diag("want: %lld", want);
+        diag("have: %"PRId64, have);
+        diag("want: %"PRId64, want);
     }
 
     va_end(args);
@@ -153,11 +154,10 @@ int tm_is(const struct TM *have, const struct TM *want, const char *name)
     return pass;
 }
 
-
 struct TM make_tm( int sec, int min, int hour, int day, int mon, Year year ) {
     struct TM date;
 
-    date.tm_year = year - 1900;
+    date.tm_year = (year_t)(year - 1900);
     date.tm_mon  = mon - 1;
     date.tm_mday  = day;
     date.tm_hour = hour;

--- a/t/tap.h
+++ b/t/tap.h
@@ -1,7 +1,9 @@
+#include <stdarg.h>
 #include "time64.h"
 
-int diag(const char, ...);
+int diag(const char*, ...);
 void skip_all(const char *);
+int do_test(const int, const char *, va_list);
 
 int ok(const int, const char *, ...);
 int is_int(const int, const int, const char *, ...);

--- a/t/tap.h
+++ b/t/tap.h
@@ -1,6 +1,12 @@
 #include <stdarg.h>
 #include "time64.h"
 
+#ifdef USE_TM64
+#define year_t Year
+#else
+#define year_t int
+#endif
+
 int diag(const char*, ...);
 void skip_all(const char *);
 int do_test(const int, const char *, va_list);

--- a/t/year_limit.t.c
+++ b/t/year_limit.t.c
@@ -1,5 +1,6 @@
-#include "time64.h"
 #include <stdio.h>
+#include <inttypes.h>
+#include "time64.h"
 #include "t/tap.h"
 
 int main(void)
@@ -17,12 +18,12 @@ int main(void)
     int  expected_mday  = 19;
 #endif
 
-    printf("# time: %lld\n", time);
+    printf("# time: %"PRId64"\n", time);
     gmtime64_r(&time, &gtime);
     printf("# sizeof time_t: %ld\n", sizeof(time_t));
     printf("# sizeof long long: %ld\n", sizeof(Time64_T));
     printf("# sizeof tm.tm_year: %ld\n", sizeof(gtime.tm_year));
-    printf("# %04lld.%02d.%02d %02d:%02d:%02d\n",
+    printf("# %04"PRId64".%02d.%02d %02d:%02d:%02d\n",
         (Year)(gtime.tm_year + 1900),
         gtime.tm_mon  + 1,
         gtime.tm_mday,

--- a/time64.c
+++ b/time64.c
@@ -597,7 +597,6 @@ struct TM *gmtime64_r (const Time64_T *in_time, struct TM *p)
     p->tm_gmtoff = 0;
 #endif
     p->tm_isdst  = 0;
-
 #ifdef HAS_TM_TM_ZONE
     p->tm_zone   = "UTC";
 #endif

--- a/time64.c
+++ b/time64.c
@@ -758,7 +758,7 @@ struct TM *localtime64_r (const Time64_T *time, struct TM *local_tm)
     /* GMT is Jan 1st, xx01 year, but localtime is still Dec 31st 
        in a non-leap xx00.  There is one point in the cycle
        we can't account for which the safe xx00 year is a leap
-       year.  So we need to correct for Dec 31st comming out as
+       year.  So we need to correct for Dec 31st coming out as
        the 366th day of the year.
     */
     if( !IS_LEAP(local_tm->tm_year) && local_tm->tm_yday == 365 )

--- a/time64.c
+++ b/time64.c
@@ -179,7 +179,7 @@ static int is_exception_century(Year year)
    The result is like cmp.
    Ignores things like gmtoffset and dst
 */
-int cmp_date( const struct TM* left, const struct tm* right ) {
+static int cmp_date( const struct TM* left, const struct tm* right ) {
     if( left->tm_year > right->tm_year )
         return 1;
     else if( left->tm_year < right->tm_year )
@@ -217,7 +217,7 @@ int cmp_date( const struct TM* left, const struct tm* right ) {
 /* Check if a date is safely inside a range.
    The intention is to check if its a few days inside.
 */
-int date_in_safe_range( const struct TM* date, const struct tm* min, const struct tm* max ) {
+static int date_in_safe_range( const struct TM* date, const struct tm* min, const struct tm* max ) {
     if( cmp_date(date, min) == -1 )
         return 0;
 
@@ -398,7 +398,7 @@ static int safe_year(const Year year)
 }
 
 
-void copy_tm_to_TM64(const struct tm *src, struct TM *dest) {
+static void copy_tm_to_TM64(const struct tm *src, struct TM *dest) {
     if( src == NULL ) {
         memset(dest, 0, sizeof(*dest));
     }
@@ -430,7 +430,7 @@ void copy_tm_to_TM64(const struct tm *src, struct TM *dest) {
 }
 
 
-void copy_TM64_to_tm(const struct TM *src, struct tm *dest) {
+static void copy_TM64_to_tm(const struct TM *src, struct tm *dest) {
     if( src == NULL ) {
         memset(dest, 0, sizeof(*dest));
     }
@@ -463,6 +463,8 @@ void copy_TM64_to_tm(const struct TM *src, struct tm *dest) {
 
 
 /* Simulate localtime_r() to the best of our ability */
+#ifndef HAS_LOCALTIME_R
+
 struct tm * fake_localtime_r(const time_t *time, struct tm *result) {
     const struct tm *static_result = localtime(time);
 
@@ -478,8 +480,12 @@ struct tm * fake_localtime_r(const time_t *time, struct tm *result) {
     }
 }
 
+#endif  /* #ifndef HAS_LOCALTIME_R */
+
 
 /* Simulate gmtime_r() to the best of our ability */
+#ifndef HAS_GMTIME_R
+
 struct tm * fake_gmtime_r(const time_t *time, struct tm *result) {
     const struct tm *static_result = gmtime(time);
 
@@ -494,6 +500,8 @@ struct tm * fake_gmtime_r(const time_t *time, struct tm *result) {
         return result;
     }
 }
+
+#endif  /* #ifndef HAS_GMTIME_R */
 
 
 static Time64_T seconds_between_years(Year left_year, Year right_year) {
@@ -786,14 +794,14 @@ struct TM *localtime64_r (const Time64_T *time, struct TM *local_tm)
 }
 
 
-int valid_tm_wday( const struct TM* date ) {
+static int valid_tm_wday( const struct TM* date ) {
     if( 0 <= date->tm_wday && date->tm_wday <= 6 )
         return 1;
     else
         return 0;
 }
 
-int valid_tm_mon( const struct TM* date ) {
+static int valid_tm_mon( const struct TM* date ) {
     if( 0 <= date->tm_mon && date->tm_mon <= 11 )
         return 1;
     else

--- a/time64.c
+++ b/time64.c
@@ -128,7 +128,8 @@ static const char dow_year_start[SOLAR_CYCLE_LENGTH] = {
 #define CHEAT_DAYS  (1199145600 / 24 / 60 / 60)
 #define CHEAT_YEARS 108
 
-#define IS_LEAP(n)      ((!(((n) + 1900) % 400) || (!(((n) + 1900) % 4) && (((n) + 1900) % 100))) != 0)
+/* IS_LEAP is used all over the place to index on arrays, so make sure it always returns 0 or 1. */
+#define IS_LEAP(n)      ( (!(((n) + 1900) % 400) || (!(((n) + 1900) % 4) && (((n) + 1900) % 100))) ? 1 : 0 )
 #define WRAP(a,b,m)     ((a) = ((a) <  0  ) ? ((b)--, (a) + (m)) : (a))
 
 #ifdef USE_SYSTEM_LOCALTIME

--- a/time64.c
+++ b/time64.c
@@ -251,7 +251,7 @@ Time64_T timegm64(const struct TM *date) {
         orig_year -= cycles * 400;
         days      += cycles * days_in_gregorian_cycle;
     }
-    TIME64_TRACE3("# timegm/ cycles: %lld, days: %lld, orig_year: %lld\n", cycles, days, orig_year);
+    TIME64_TRACE3("# timegm/ cycles: %"PRId64", days: %"PRId64", orig_year: %"PRId64"\n", cycles, days, orig_year);
 
     if( orig_year > 70 ) {
         year = 70;
@@ -332,7 +332,7 @@ static Year cycle_offset(Year year)
     exceptions  = year_diff / 100;
     exceptions -= year_diff / 400;
 
-    TIME64_TRACE3("# year: %lld, exceptions: %lld, year_diff: %lld\n",
+    TIME64_TRACE3("# year: %"PRId64", exceptions: %"PRId64", year_diff: %"PRId64"\n",
           year, exceptions, year_diff);
 
     return exceptions * 16;
@@ -391,7 +391,7 @@ static int safe_year(const Year year)
     else
         assert(0);
 
-    TIME64_TRACE3("# year: %lld, year_cycle: %lld, safe_year: %d\n",
+    TIME64_TRACE3("# year: %"PRId64", year_cycle: %"PRId64", safe_year: %d\n",
           year, year_cycle, safe_year);
 
     assert(safe_year <= MAX_SAFE_YEAR && safe_year >= MIN_SAFE_YEAR);
@@ -550,8 +550,8 @@ Time64_T mktime64(struct TM *input_date) {
     /* Have to make the year safe in date else it won't fit in safe_date */
     date = *input_date;
     date.tm_year = safe_year(year) - 1900;
-    copy_TM64_to_tm(&date, &safe_date);
 
+    copy_TM64_to_tm(&date, &safe_date);
     time = (Time64_T)mktime(&safe_date);
 
     /* Correct the user's possibly out of bound input date */
@@ -714,7 +714,7 @@ struct TM *localtime64_r (const Time64_T *time, struct TM *local_tm)
     if( SHOULD_USE_SYSTEM_LOCALTIME(*time) ) {
         safe_time = (time_t)*time;
 
-        TIME64_TRACE1("Using system localtime for %lld\n", *time);
+        TIME64_TRACE1("Using system localtime for %"PRId64"\n", *time);
 
         LOCALTIME_R(&safe_time, &safe_date);
 
@@ -725,7 +725,7 @@ struct TM *localtime64_r (const Time64_T *time, struct TM *local_tm)
     }
 
     if( gmtime64_r(time, &gm_tm) == NULL ) {
-        TIME64_TRACE1("gmtime64_r returned null for %lld\n", *time);
+        TIME64_TRACE1("gmtime64_r returned null for %"PRId64"\n", *time);
         return NULL;
     }
 
@@ -735,7 +735,7 @@ struct TM *localtime64_r (const Time64_T *time, struct TM *local_tm)
         gm_tm.tm_year < (1970 - 1900)
        )
     {
-        TIME64_TRACE1("Mapping tm_year %lld to safe_year\n", (Year)gm_tm.tm_year);
+        TIME64_TRACE1("Mapping tm_year %"PRId64" to safe_year\n", (Year)gm_tm.tm_year);
         gm_tm.tm_year = safe_year((Year)(gm_tm.tm_year + 1900)) - 1900;
     }
 
@@ -754,7 +754,7 @@ struct TM *localtime64_r (const Time64_T *time, struct TM *local_tm)
 #   endif
 
     if( local_tm->tm_year != orig_year ) {
-        TIME64_TRACE2("tm_year overflow: tm_year %lld, orig_year %lld\n",
+        TIME64_TRACE2("tm_year overflow: tm_year %"PRId64", orig_year %"PRId64"\n",
               (Year)local_tm->tm_year, (Year)orig_year);
 
 #ifdef EOVERFLOW

--- a/time64.c
+++ b/time64.c
@@ -234,19 +234,19 @@ Time64_T timegm64(const struct TM *date) {
     Time64_T seconds = 0;
     Year     year;
     Year     orig_year = (Year)date->tm_year;
-    int      cycles  = 0;
+    Year     cycles  = 0;
 
     if( orig_year > 100 ) {
         cycles = (orig_year - 100) / 400;
         orig_year -= cycles * 400;
-        days      += (Time64_T)cycles * days_in_gregorian_cycle;
+        days      += cycles * days_in_gregorian_cycle;
     }
     else if( orig_year < -300 ) {
         cycles = (orig_year - 100) / 400;
         orig_year -= cycles * 400;
-        days      += (Time64_T)cycles * days_in_gregorian_cycle;
+        days      += cycles * days_in_gregorian_cycle;
     }
-    TIME64_TRACE3("# timegm/ cycles: %d, days: %lld, orig_year: %lld\n", cycles, days, orig_year);
+    TIME64_TRACE3("# timegm/ cycles: %lld, days: %lld, orig_year: %lld\n", cycles, days, orig_year);
 
     if( orig_year > 70 ) {
         year = 70;
@@ -496,7 +496,7 @@ struct tm * fake_gmtime_r(const time_t *time, struct tm *result) {
 static Time64_T seconds_between_years(Year left_year, Year right_year) {
     int increment = (left_year > right_year) ? 1 : -1;
     Time64_T seconds = 0;
-    int cycles;
+    Year cycles;
 
     if( left_year > 2400 ) {
         cycles = (left_year - 2400) / 400;
@@ -564,7 +564,7 @@ struct TM *gmtime64_r (const Time64_T *in_time, struct TM *p)
     Time64_T m;
     Time64_T time = *in_time;
     Year year = 70;
-    int cycles = 0;
+    Year cycles = 0;
 
     assert(p != NULL);
 
@@ -613,10 +613,10 @@ struct TM *gmtime64_r (const Time64_T *in_time, struct TM *p)
 
     if (m >= 0) {
         /* Gregorian cycles, this is huge optimization for distant times */
-        cycles = (int)(m / (Time64_T) days_in_gregorian_cycle);
+        cycles = m / (Time64_T) days_in_gregorian_cycle;
         if( cycles ) {
-            m -= (cycles * (Time64_T) days_in_gregorian_cycle);
-            year += (cycles * years_in_gregorian_cycle);
+            m -= cycles * (Time64_T) days_in_gregorian_cycle;
+            year += cycles * years_in_gregorian_cycle;
         }
 
         /* Years */
@@ -637,10 +637,10 @@ struct TM *gmtime64_r (const Time64_T *in_time, struct TM *p)
         year--;
 
         /* Gregorian cycles */
-        cycles = (int)((m / (Time64_T) days_in_gregorian_cycle) + 1);
+        cycles = (m / (Time64_T) days_in_gregorian_cycle) + 1;
         if( cycles ) {
-            m -= (cycles * (Time64_T) days_in_gregorian_cycle);
-            year += (cycles * years_in_gregorian_cycle);
+            m -= cycles * (Time64_T) days_in_gregorian_cycle;
+            year += cycles * years_in_gregorian_cycle;
         }
 
         /* Years */

--- a/time64.c
+++ b/time64.c
@@ -660,7 +660,12 @@ struct TM *gmtime64_r (const Time64_T *in_time, struct TM *p)
         m += (Time64_T) days_in_month[leap][v_tm_mon];
     }
 
-    p->tm_year = year;
+#   ifdef USE_TM64
+      p->tm_year = year;
+#   else
+      p->tm_year = (int)year;
+#   endif
+
     if( p->tm_year != year ) {
 #ifdef EOVERFLOW
         errno = EOVERFLOW;
@@ -730,7 +735,12 @@ struct TM *localtime64_r (const Time64_T *time, struct TM *local_tm)
 
     copy_tm_to_TM64(&safe_date, local_tm);
 
-    local_tm->tm_year = orig_year;
+#   ifdef USE_TM64
+      local_tm->tm_year = orig_year;
+#   else
+      local_tm->tm_year = (int)orig_year;
+#   endif
+
     if( local_tm->tm_year != orig_year ) {
         TIME64_TRACE2("tm_year overflow: tm_year %lld, orig_year %lld\n",
               (Year)local_tm->tm_year, (Year)orig_year);

--- a/time64.c
+++ b/time64.c
@@ -280,7 +280,10 @@ static int check_tm(struct TM *tm)
 {
     /* Don't forget leap seconds */
     assert(tm->tm_sec >= 0);
-    assert(tm->tm_sec <= 61);
+
+    /* Allow for just one positive leap second, which is what the C99 standard says. */
+    /* Two leap seconds in the same minute are not allowed (the C90 range 0..61 was a defect). */
+    assert(tm->tm_sec <= 60);
 
     assert(tm->tm_min >= 0);
     assert(tm->tm_min <= 59);

--- a/time64.c
+++ b/time64.c
@@ -130,7 +130,9 @@ static const char dow_year_start[SOLAR_CYCLE_LENGTH] = {
 
 /* IS_LEAP is used all over the place to index on arrays, so make sure it always returns 0 or 1. */
 #define IS_LEAP(n)      ( (!(((n) + 1900) % 400) || (!(((n) + 1900) % 4) && (((n) + 1900) % 100))) ? 1 : 0 )
-#define WRAP(a,b,m)     ((a) = ((a) <  0  ) ? ((b)--, (a) + (m)) : (a))
+
+/* Allegedly, some <termios.h> define a macro called WRAP, so use a longer name like WRAP_TIME64. */
+#define WRAP_TIME64(a,b,m)     ((a) = ((a) <  0  ) ? ((b)--, (a) + (m)) : (a))
 
 #ifdef USE_SYSTEM_LOCALTIME
 #    define SHOULD_USE_SYSTEM_LOCALTIME(a)  (       \
@@ -598,9 +600,9 @@ struct TM *gmtime64_r (const Time64_T *in_time, struct TM *p)
     time /= 24;
     v_tm_tday = time;
 
-    WRAP (v_tm_sec, v_tm_min, 60);
-    WRAP (v_tm_min, v_tm_hour, 60);
-    WRAP (v_tm_hour, v_tm_tday, 24);
+    WRAP_TIME64 (v_tm_sec, v_tm_min, 60);
+    WRAP_TIME64 (v_tm_min, v_tm_hour, 60);
+    WRAP_TIME64 (v_tm_hour, v_tm_tday, 24);
 
     v_tm_wday = (int)((v_tm_tday + 4) % 7);
     if (v_tm_wday < 0)

--- a/time64.c
+++ b/time64.c
@@ -109,6 +109,7 @@ static const int safe_years_low[SOLAR_CYCLE_LENGTH] = {
     1992, 1993, 1994, 1995,
 };
 
+#if 0
 /* This isn't used, but it's handy to look at */
 static const char dow_year_start[SOLAR_CYCLE_LENGTH] = {
     5, 0, 1, 2,     /* 0       2016 - 2019 */
@@ -119,6 +120,7 @@ static const char dow_year_start[SOLAR_CYCLE_LENGTH] = {
     2, 4, 5, 6,     /* 20      2036, 2037, 2010, 2011 */
     0, 2, 3, 4      /* 24      2012, 2013, 2014, 2015 */
 };
+#endif
 
 /* Let's assume people are going to be looking for dates in the future.
    Let's provide some cheats so you can skip ahead.

--- a/time64.h
+++ b/time64.h
@@ -27,7 +27,7 @@ struct TM64 {
 #endif
 
 #ifdef HAS_TM_TM_ZONE
-        char    *tm_zone;
+        const char *tm_zone;
 #endif
 };
 

--- a/time64.h
+++ b/time64.h
@@ -13,6 +13,13 @@ typedef INT_64_T        Int64;
 typedef Int64           Time64_T;
 typedef Int64           Year;
 
+#ifndef PRId64
+# if (__WORDSIZE == 64) && !defined(__APPLE__)
+#  define PRId64 "ld"
+# else
+#  define PRId64 "lld"
+# endif
+#endif
 
 /* A copy of the tm struct but with a 64 bit year */
 struct TM64 {
@@ -76,7 +83,7 @@ Time64_T   timelocal64   (struct TM *);
 
 /* Use a different asctime format depending on how big the year is */
 #ifdef USE_TM64
-    #define TM64_ASCTIME_FORMAT "%.3s %.3s%3d %.2d:%.2d:%.2d %lld\n"
+    #define TM64_ASCTIME_FORMAT "%.3s %.3s%3d %.2d:%.2d:%.2d %"PRId64"\n"
 #else
     #define TM64_ASCTIME_FORMAT "%.3s %.3s%3d %.2d:%.2d:%.2d %d\n"
 #endif

--- a/time64.h
+++ b/time64.h
@@ -4,6 +4,10 @@
 #include <time.h>
 #include "time64_config.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Set our custom types */
 typedef INT_64_T        Int64;
 typedef Int64           Time64_T;
@@ -77,5 +81,8 @@ Time64_T   timelocal64   (struct TM *);
     #define TM64_ASCTIME_FORMAT "%.3s %.3s%3d %.2d:%.2d:%.2d %d\n"
 #endif
 
+#ifdef __cplusplus
+  };
+#endif
 
 #endif

--- a/time64_config.h
+++ b/time64_config.h
@@ -49,12 +49,15 @@
 /* Details of non-standard tm struct elements.
 
    HAS_TM_TM_GMTOFF
-   True if your tm struct has a "tm_gmtoff" element.
+   Defined if your tm struct has a "tm_gmtoff" element.
    A BSD extension.
 
    HAS_TM_TM_ZONE
-   True if your tm struct has a "tm_zone" element.
+   Defined if your tm struct has a "tm_zone" element.
    A BSD extension.
+
+   If you define these symbols Under Linux/glibc, you either need to define _BSD_SOURCE before including time.h,
+   or change time64's source code to use names __tm_gmtoff and __tm_zone instead of tm_gmtoff and tm_zone.
 */
 /* #define HAS_TM_TM_GMTOFF */
 /* #define HAS_TM_TM_ZONE */

--- a/time64_config.h
+++ b/time64_config.h
@@ -4,6 +4,8 @@
    Sensible defaults provided.
 */
 
+#include <stdint.h>   /* If your system does not have stdint.h or does not define int64_t, you can use 'long long' instead, */
+                      /* but then make sure that 'long long' is indeed a 64-bit signed integer on your platform. */
 
 #ifndef TIME64_CONFIG_H
 #    define TIME64_CONFIG_H
@@ -19,7 +21,7 @@
    A 64 bit integer type to use to store time and others.
    Must be defined.
 */
-#define INT_64_T                long long
+#define INT_64_T                int64_t
 
 
 /* USE_TM64

--- a/time64_limits.h
+++ b/time64_limits.h
@@ -1,6 +1,7 @@
-/* 
+/* This header file is to be considered private to time64.c, so do not include it from your code.
+
    Maximum and minimum inputs your system's respective time functions
-   can correctly handle.  time64.h will use your system functions if
+   can correctly handle.  time64 will use your system functions if
    the input falls inside these ranges and corresponding USE_SYSTEM_*
    constant is defined.
 */


### PR DESCRIPTION
merge and fix rdiez' improvements.
improve the Makefile, detect Linux and Darwin, and add the needed HAS_TM defines.
  support make DEBUG=1 and USE_TM64=1
add tap.h declarations
replace %lld printf with %PRId64 from inttypes.h
Fix fragile t/mktime64.t
  use an hour which does not overflow to the next or prev day.
  test all kind of years, esp. leap years with out of bound dates

various minor optimizations
